### PR TITLE
docs: API 택배사 코드 추가에 따른 매뉴얼 수정

### DIFF
--- a/RESTAPI/logis.md
+++ b/RESTAPI/logis.md
@@ -1,8 +1,8 @@
-# 택배사 코드표  
+# 택배사 코드표
 
-:globe_with_meridians: [EN](/en/RESTAPI/logis.md)  
+:globe_with_meridians: [EN](/en/RESTAPI/logis.md)
 
-이용하시는 PG사 상관없이 동일한 코드표가 적용됩니다.  
+이용하시는 PG사 상관없이 동일한 코드표가 적용됩니다.
 
 | 택배사 코드 | 택배사 이름 |
 | ---------- | - |
@@ -18,5 +18,11 @@
 | CJGLS | CJ대한통운 |
 | HANJIN | 한진택배 |
 | DAESIN | 대신택배 |
+| REGISTPOST | 우편등기 |
+| CHUNIL | 천일택배 |
+| ILYANG | 일양로지스 |
+| CVSNET | 편의점택배 |
+| KDEXP | 경동택배 |
+| HONAM | 우리택배(구 호남택배) |
+| HDEXP | 합동택배 |
 | ETC | 기타(위 코드표에 해당되지 않는 값이 전달되면 ETC로 자동 처리됩니다) |
-

--- a/en/RESTAPI/logis.md
+++ b/en/RESTAPI/logis.md
@@ -1,8 +1,8 @@
-# Courier Codes   
+# Courier Codes
 
-:globe_with_meridians: [KO](/RESTAPI/logis.md)  
+:globe_with_meridians: [KO](/RESTAPI/logis.md)
 
-The following courier codes apply to all PGs.  
+The following courier codes apply to all PGs.
 
 | Courier Code | Courier Name |
 | ---------- | - |
@@ -18,4 +18,11 @@ The following courier codes apply to all PGs.
 | CJGLS | CJ Korea Express |
 | HANJIN | Hanjin Global Logistics |
 | DAESIN | Daesin Parcel |
+| REGISTPOST | Postal registration |
+| CHUNIL | Chunil Parcel |
+| ILYANG | Ilyang Logis |
+| CVSNET | Convenience store delivery |
+| KDEXP | KD Express |
+| HONAM | Woori Logis(Honam Logis) |
+| HDEXP | Hapdong Express |
 | ETC | Other (Code that does not match any of the above codes) |


### PR DESCRIPTION
[API 택배사 코드 추가 작업](https://github.com/iamport/api-iamport/pull/254)에 따라 사용 가능한 택배사 코드 추가했습니다.
택배사 코드는 [이니시스 택배사코드](https://manual.inicis.com/code/#gls) 참고했습니다.

### 추가된 코드 

- REGISTPOST: 우편등기
- CHUNIL: 천일택배
- ILYANG: 일양로지스
- CVSNET: 편의점택배
- KDEXP: 경동택배
- HONAM: 우리택배(구 호남택배)
- HDEXP: 합동택배

### 기타 링크

- [에스크로 배송등록시 미지원되는 택배사 코드(API) 추가건 노션](https://www.notion.so/chaifinance/API-9998617d2b7e4128bb2147a70d80386a)