### PR TITLE
feat: KCP 결제 요청의 site_logo 파라미터 설명 추가

### DIFF
--- a/비인증결제/example/kcp-request-billing-key.md
+++ b/비인증결제/example/kcp-request-billing-key.md
@@ -26,16 +26,19 @@ PC의 경우 `IMP.request_pay(param, callback)` 호출 후 callback으로 실행
 
 ```javascript
 IMP.request_pay({
-   pg : 'kcp_billing',
+	pg : 'kcp_billing',
 	pay_method : 'card', // 'card'만 지원됩니다.
-	merchant_uid: "order_monthly_0001", // 상점에서 관리하는 주문 번호
+	merchant_uid: 'order_monthly_0001', // 상점에서 관리하는 주문 번호
 	name : '최초인증결제',
 	amount : 0, // 결제창에 표시될 금액. 실제 승인이 이뤄지지는 않습니다. (PC에서는 가격이 표시되지 않음)
 	customer_uid : 'your-customer-unique-id', // 필수 입력.
 	buyer_email : 'iamport@siot.do',
 	buyer_name : '아임포트',
 	buyer_tel : '02-1234-1234',
-	m_redirect_url : '{모바일에서 결제 완료 후 리디렉션 될 URL}' // 예: https://www.my-service.com/payments/complete/mobile
+	m_redirect_url : '{모바일에서 결제 완료 후 리디렉션 될 URL}', // 예: https://www.my-service.com/payments/complete/mobile
+	bypass : {
+		site_logo : '{상점의 로고가 있는 정확한 URL}'  // 설정 시 결제 창 왼쪽 상단에 로고를 띄웁니다. 결제 창 호출이 느려질 수 있으며 150 X 50 미만 GIF, JPG 파일만 지원.
+	}
 }, function(rsp) {
 	if ( rsp.success ) {
 		alert('빌링키 발급 성공');

--- a/인증결제/sample/kcp.md
+++ b/인증결제/sample/kcp.md
@@ -27,7 +27,7 @@ PC의 경우 `IMP.request_pay(param, callback)` 호출 후 callback으로 실행
 IMP.request_pay({
     pg : 'kcp',
     pay_method : 'card',
-    merchant_uid: "order_no_0001", //상점에서 생성한 고유 주문번호
+    merchant_uid: 'order_no_0001', // 상점에서 생성한 고유 주문번호
     name : '주문명:결제테스트',
     amount : 14000,
     buyer_email : 'iamport@siot.do',
@@ -35,7 +35,10 @@ IMP.request_pay({
     buyer_tel : '010-1234-5678',
     buyer_addr : '서울특별시 강남구 삼성동',
     buyer_postcode : '123-456',
-    m_redirect_url : '{모바일에서 결제 완료 후 리디렉션 될 URL}' // 예: https://www.my-service.com/payments/complete/mobile
+    m_redirect_url : '{모바일에서 결제 완료 후 리디렉션 될 URL}', // 예: https://www.my-service.com/payments/complete/mobile
+    bypass : {
+        site_logo : '{상점의 로고가 있는 정확한 URL}'  // 설정 시 결제 창 왼쪽 상단에 로고를 띄웁니다. 결제 창 호출이 느려질 수 있으며 150 X 50 미만 GIF, JPG 파일만 지원.
+    }
 }, function(rsp) { // callback 로직
 	//* ...중략 (README 파일에서 상세 샘플코드를 확인하세요)... *//
 });


### PR DESCRIPTION
[PORT-355](https://chai-corporation.atlassian.net/browse/PORT-355)

- KCP 일반 결제 결제창 호출 시 site_logo를 지정하면 로고가 표시되는 기능이 현재 이미 지원중이며
- 2022-09-21부터는 위 파라미터를 KCP 빌링 결제에서도 지원할 예정입니다.

따라서 이에 대한 설명을 아임포트 메뉴얼에 추가합니다.

추가한 설명은 KCP developers 가맹점 개발지원센터에 적힌[1] 다음 설명을 참고해 작성했습니다.

> **site_logo** (string, 256)
>
> 결제 창 왼쪽 상단에 가맹점 사이트의 로고를 띄움니다.
> 업체의 로고가 있는 URL을 정확히 입력해야 하며 해당 변수 생략 시에는 로고가 뜨지 않고 site_name 값이 표시됨
> 로고 파일은 GIF, JPG 파일만 지원
> 최대 사이즈 : 150 X 50 미만
> 이미지 파일을 150 X 50 이상으로 설정 시 site_name 값이 표시됨
> ※ site_logo 설정 시 결제 창 호출이 느려질 수 있음

1: https://developer.kcp.co.kr/page/document/web 주문요청 파라미터 가이드 &rarr; 옵션 &rarr; 추가 옵션 변수